### PR TITLE
Fix: Incorrect 'NumericValue' in 'NumericInput.cs'.

### DIFF
--- a/Iguina/Entities/NumericInput.cs
+++ b/Iguina/Entities/NumericInput.cs
@@ -244,7 +244,7 @@ namespace Iguina.Entities
                 _plusButton = plusButton;
             }
 
-            // add + button
+            // add - button
             if (addMinusButton)
             {
                 var minusButton = new Button(system, buttonStyle, "-");

--- a/Iguina/Entities/NumericInput.cs
+++ b/Iguina/Entities/NumericInput.cs
@@ -88,8 +88,8 @@ namespace Iguina.Entities
                     }
 
                     // set value
-                    base.Value = value;
                     _valueFloat = result;
+                    base.Value = value;
                 }
 
                 // failed to parse? don't change value!


### PR DESCRIPTION
Reason of the incorrect value is that the '_valueFloat' field is placed after 'base.Value = value;', which triggers the 'OnValueChanged' event before the 'NumericValue' property could be updated.

The solution is to update the '_valueFloat' field before setting the 'base.Value'.

---

Test this bug like this:

```c#
var numericInput = panel.AddChild(new NumericInput(_system));
numericInput.Events.OnValueChanged = (Entity entity) =>
{
    numericInput.NumericValue.ToString(); // without the fix, this value is wrong!
};
```

This **_only_** happens when changing the number directly via **text input**.