### PR TITLE
Fix: Manualy setting a scrollbar's visibility to "false" had no Effect

### DIFF
--- a/Iguina/Entities/ListBox.cs
+++ b/Iguina/Entities/ListBox.cs
@@ -157,13 +157,16 @@ namespace Iguina.Entities
         /// </summary>
         protected virtual bool ShowListScrollbar => (_paragraphs.Count < _items.Count);
 
+        // Flag to track if scrollbar visibility was manually set
+        private bool _manualScrollbarVisibilitySet = false;
+
         /// <summary>
         /// Create the list box.
         /// </summary>
         /// <param name="system">Parent UI system.</param>
         /// <param name="stylesheet">List box panel stylesheet.</param>
         /// <param name="itemsStylesheet">List box items stylesheet. If not set, will use the same as base stylesheet.</param>
-        public ListBox(UISystem system, StyleSheet? stylesheet, StyleSheet? itemsStylesheet = null) : base(system, stylesheet) 
+        public ListBox(UISystem system, StyleSheet? stylesheet, StyleSheet? itemsStylesheet = null) : base(system, stylesheet)
         {
             ItemsStyleSheet = itemsStylesheet ?? StyleSheet;
 
@@ -191,10 +194,22 @@ namespace Iguina.Entities
         /// Create the list box with default stylesheets.
         /// </summary>
         /// <param name="system">Parent UI system.</param>
-        public ListBox(UISystem system) : this(system, 
-            system.DefaultStylesheets.ListPanels ?? system.DefaultStylesheets.Panels, 
+        public ListBox(UISystem system) : this(system,
+            system.DefaultStylesheets.ListPanels ?? system.DefaultStylesheets.Panels,
             system.DefaultStylesheets.ListItems ?? system.DefaultStylesheets.Paragraphs)
         {
+        }
+
+        /// <summary>
+        /// Override the scrollbar's Visible property to allow direct control.
+        /// </summary>
+        public void SetScrollbarVisible(bool visible)
+        {
+            if (VerticalScrollbar != null)
+            {
+                _manualScrollbarVisibilitySet = true;
+                VerticalScrollbar.Visible = visible;
+            }
         }
 
         /// <inheritdoc/>
@@ -279,7 +294,7 @@ namespace Iguina.Entities
                     // pass click to self
                     this.Events.OnClick?.Invoke(this);
                 };
-                
+
                 // add new paragraph
                 AddChildInternal(p);
                 p.IgnoreScrollOffset = true;
@@ -298,9 +313,15 @@ namespace Iguina.Entities
             // show / hide scrollbar
             if (VerticalScrollbar != null)
             {
-                VerticalScrollbar.Visible = ShowListScrollbar;
+                // Only set scrollbar visibility based on ShowListScrollbar if not manually set
+                if (!_manualScrollbarVisibilitySet)
+                {
+                    VerticalScrollbar.Visible = ShowListScrollbar;
+                }
                 VerticalScrollbar.MaxValue = (_items.Count - _paragraphs.Count) + 1;
-                scrollOffset = VerticalScrollbar.Visible ? VerticalScrollbar.Value : 0;
+
+                // Always use the value from the scrollbar regardless of visibility
+                scrollOffset = VerticalScrollbar.Value;
             }
 
             // set paragraphs values

--- a/Iguina/Entities/Panel.cs
+++ b/Iguina/Entities/Panel.cs
@@ -56,7 +56,7 @@ namespace Iguina.Entities
         /// <inheritdoc/>
         internal override void PerformMouseWheelScroll(int val)
         {
-            if ((VerticalScrollbar != null) && (VerticalScrollbar.Visible))
+            if (VerticalScrollbar != null && VerticalScrollbar.Enabled)
             {
                 VerticalScrollbar.PerformMouseWheelScroll(val);
             }


### PR DESCRIPTION
Manualy setting a scrollbar's visibility to "false" had no effect. With this fix it is possible to hide the scrollbar while still retaining mouse-wheel and keyboard scrolling.

In the **Panel** entity I also exchanged `if ((VerticalScrollbar != null) && (VerticalScrollbar.Visible))` with  `if (VerticalScrollbar != null && VerticalScrollbar.Enabled)` in the "PerformMouseWheelScroll"-Method to still make it possible to block scrolling by disabling the scrollbar.

---

I made this fix because in some circumstances it just doesn't look right to have the scrollbar visible (imagine touch support). Also creating a stylesheet for something which is already in the code (Entity.Visible) seems to be overshooting. However setting `VerticalScrollbar.Visible = false;` obviously is not working as intended because it gets overwritten by `VerticalScrollbar.Visible = ShowListScrollbar;` in the **DrawEntityType** method of the **ListBox** entity. The **DropDown** entity doesn't seem to implement the same logik for checking if the scrollbar should be visible.